### PR TITLE
Fix wrong monitor socket path when OAR job is killed

### DIFF
--- a/lib/vagrant-g5k/util/launch_vm.sh
+++ b/lib/vagrant-g5k/util/launch_vm.sh
@@ -73,7 +73,7 @@ export TMPDIR=/tmp
 # Clean shutdown of the VM at the end of the OAR job
 clean_shutdown() {
   echo "Caught shutdown signal at $(date)"
-  echo "system_powerdown" | nc -U /tmp/vagrant-g5k.mon
+  echo "system_powerdown" | nc -U /tmp/vagrant-g5k.$OAR_JOB_ID.mon
 }
 
 trap clean_shutdown 12


### PR DESCRIPTION
Commit 2566320bf1 ("Make to monitor socket location unique") forgot to
update the path to the socket in the cleanup function, resulting in an
unclean shutdown of the VM.